### PR TITLE
No more left/right shifting of content

### DIFF
--- a/css/sourcefu.css
+++ b/css/sourcefu.css
@@ -2,6 +2,11 @@ body {
   padding-top: 40px;
   padding-bottom: 40px;
 }
+
+.container {
+  margin-left: 2em;
+}
+
 @media (max-width: 979px) {
   body {
     padding-top: 0;


### PR DESCRIPTION
Left-aligning the main content area (#container) so it doesn't shift when there's is and isn't a scrollbar in the browser for long content.
